### PR TITLE
Property pansAcross behaves opposite of expected.

### DIFF
--- a/KenBurns/Classes/KenBurns.swift
+++ b/KenBurns/Classes/KenBurns.swift
@@ -39,13 +39,13 @@ class KenBurnsAnimation : Equatable {
         let range = (min: (1 - zoom), max: 0.0)
         if pansAcross {
             offsets = (
-                x: range.min,
-                y: Random.double(0.3 * range.min, 0.7 * range.min)
+                x: Random.double(range.min, range.max),
+                y: Random.double(range.min, range.max)
             )
         } else {
             offsets = (
-                x: Random.double(range.min, range.max),
-                y: Random.double(range.min, range.max)
+                x: range.min,
+                y: Random.double(0.3 * range.min, 0.7 * range.min)
             )
         }
     }
@@ -113,7 +113,7 @@ func ==(lhs: KenBurnsAnimation, rhs: KenBurnsAnimation) -> Bool {
 
 @objc public class KenBurnsImageView: UIView {
     public var loops = true
-    public var pansAcross = false
+    public var pansAcross = true
     public var zoomIntensity = 1.0
     public var durationRange: DurationRange = (min: 10, max: 20)
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ You can also initialize with a direct `UIImage` rather than a URL, and there are
 func newKenBurnsImageView(image: UIImage) -> KenBurnsImageView {
     let ken = KenBurnsImageView()
     ken.setImage(image: image)
-    ken.zoomIntensity = 1.5
+    ken.zoomIntensity = 1.5 // Defaults to 1.0.
     ken.setDuration(min: 5, max: 13)
+    ken.pansAcross = false // Defaults to true.
     ken.startAnimating()
     return ken
 }


### PR DESCRIPTION
To be honest I'm not completely sure about this, since there was some adjustment along the x-axis when pansAcross was set to true. But it was constant and based on the zoom.

I would expect pansAcross==true to give random pans, so I assume it was an error.
The property defaulted to false and wasn't in the readme, so chances are most wouldn't notice.

If have changed the property to default to true instead, meaning existing users who upgrade won't be affected by it as long as the haven't set the property specifically.
