### PR TITLE
Expose instance method updateAllAnimations() for Swift 4 compat

### DIFF
--- a/KenBurns/Classes/KenBurns.swift
+++ b/KenBurns/Classes/KenBurns.swift
@@ -225,7 +225,7 @@ func ==(lhs: KenBurnsAnimation, rhs: KenBurnsAnimation) -> Bool {
         animations.append(animation)
     }
 
-    func updateAllAnimations() {
+    @objc func updateAllAnimations() {
         animations.forEach {
             $0.update(self.w, self.h)
         }


### PR DESCRIPTION
Before Swift 4 this was implicitly inferred. Without this using Swift 4, there will be compilation errors.